### PR TITLE
Added ice shelves to Kerbin's biomes

### DIFF
--- a/js/ksp.parser.js
+++ b/js/ksp.parser.js
@@ -295,7 +295,7 @@ function kspUniverse(){
 			'name':'Kerbin',
 			'orbiting_body':'Sun',
 			'body_type':'atm_rocky_liquid',
-			'biomes':['Grasslands','Highlands','Mountains','Deserts','Badlands','Tundra','IceCaps','Water','Shores','KSC','Administration','AstronautComplex','FlagPole','LaunchPad','Crawlerway','VAB','VABPodMemorial','VABMainBuilding','VABSouthComplex','VABTanks','VABRoundTank','Runway','SPH','SPHMainBuilding','SPHWaterTower','SPHRoundTank','SPHTanks','TrackingStation','TrackingStationDishEast','TrackingStationDishSouth','TrackingStationDishNorth','TrackingStationHub','R&D','R&DCentralBuilding','R&DSmallLab','R&DMainBuilding','R&DObservatory','R&DCornerLab','R&DTanks','R&DWindTunnel','R&DSideLab','MissionControl']	//	Crawerlway	Administration	Astronaut Complex	Mission Control	Research and Development	Spaceplane Hanger	Tracking Station	Vehicle Assembly Building
+			'biomes':['Grasslands','Highlands','Mountains','Deserts','Badlands','Tundra','IceCaps','NorthernIceShelf','SouthernIceShelf','Water','Shores','KSC','Administration','AstronautComplex','FlagPole','LaunchPad','Crawlerway','VAB','VABPodMemorial','VABMainBuilding','VABSouthComplex','VABTanks','VABRoundTank','Runway','SPH','SPHMainBuilding','SPHWaterTower','SPHRoundTank','SPHTanks','TrackingStation','TrackingStationDishEast','TrackingStationDishSouth','TrackingStationDishNorth','TrackingStationHub','R&D','R&DCentralBuilding','R&DSmallLab','R&DMainBuilding','R&DObservatory','R&DCornerLab','R&DTanks','R&DWindTunnel','R&DSideLab','MissionControl']	//	Crawerlway	Administration	Astronaut Complex	Mission Control	Research and Development	Spaceplane Hanger	Tracking Station	Vehicle Assembly Building
 		},
 			{
 				'ident':'Mun',


### PR DESCRIPTION
Kerbin has two additional biomes near the poles.  They are named
'NorthernIceShelf' and 'SouthernIceShelf'.  These biomes were added
to the wiki https://wiki.kerbalspaceprogram.com/wiki/Biome#Kerbin
some time ago, and I suspect they were added to the game in v1.2.